### PR TITLE
Add MDM packages

### DIFF
--- a/goztl.go
+++ b/goztl.go
@@ -73,6 +73,7 @@ type Client struct {
 	MDMLocations                  MDMLocationsService
 	MDMLocationAssets             MDMLocationAssetsService
 	MDMOTAEnrollments             MDMOTAEnrollmentsService
+	MDMPackages                   MDMPackagesService
 	MDMProfiles                   MDMProfilesService
 	MDMProvisioningProfiles       MDMProvisioningProfilesService
 	MDMPushCertificates           MDMPushCertificatesService
@@ -274,6 +275,7 @@ func NewClient(httpClient *http.Client, bu string, token string, opts ...ClientO
 	c.MDMLocations = &MDMLocationsServiceOp{client: c}
 	c.MDMLocationAssets = &MDMLocationAssetsServiceOp{client: c}
 	c.MDMOTAEnrollments = &MDMOTAEnrollmentsServiceOp{client: c}
+	c.MDMPackages = &MDMPackagesServiceOp{client: c}
 	c.MDMProfiles = &MDMProfilesServiceOp{client: c}
 	c.MDMProvisioningProfiles = &MDMProvisioningProfilesServiceOp{client: c}
 	c.MDMPushCertificates = &MDMPushCertificatesServiceOp{client: c}

--- a/mdm_packages.go
+++ b/mdm_packages.go
@@ -1,0 +1,186 @@
+package goztl
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const mpkgBasePath = "mdm/packages/"
+
+// MDMPackagesService is an interface for interfacing with the MDM package
+// endpoints of the Zentral API
+type MDMPackagesService interface {
+	List(context.Context, *ListOptions) ([]MDMPackage, *Response, error)
+	GetByID(context.Context, string) (*MDMPackage, *Response, error)
+	GetByName(context.Context, string) ([]MDMPackage, *Response, error)
+	Create(context.Context, *MDMPackageCreateRequest) (*MDMPackage, *Response, error)
+	Update(context.Context, string, *MDMPackageUpdateRequest) (*MDMPackage, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+}
+
+// MDMPackagesServiceOp handles communication with the MDM packages related
+// methods of the Zentral API.
+type MDMPackagesServiceOp struct {
+	client *Client
+}
+
+var _ MDMPackagesService = &MDMPackagesServiceOp{}
+
+// MDMPackage represents a Zentral MDM package
+type MDMPackage struct {
+	ID             string                   `json:"id"`
+	Name           string                   `json:"name"`
+	Description    string                   `json:"description"`
+	Type           string                   `json:"type"`
+	SourceURI      string                   `json:"source_uri"`
+	SHA256         string                   `json:"sha256"`
+	Size           int64                    `json:"size"`
+	Filename       string                   `json:"filename"`
+	ProductID      string                   `json:"product_id"`
+	ProductVersion string                   `json:"product_version"`
+	Bundles        []map[string]interface{} `json:"bundles"`
+	Manifest       map[string]interface{}   `json:"manifest"`
+	Created        Timestamp                `json:"created_at"`
+	Updated        Timestamp                `json:"updated_at"`
+}
+
+func (mp MDMPackage) String() string {
+	return Stringify(mp)
+}
+
+// MDMPackageCreateRequest represents a request to create a MDM package.
+type MDMPackageCreateRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	SourceURI   string `json:"source_uri"`
+	SHA256      string `json:"sha256"`
+}
+
+// MDMPackageUpdateRequest represents a request to update a MDM package. Only
+// name and description are mutable post-create — the underlying file, and
+// therefore source_uri and sha256, are fixed at creation time.
+type MDMPackageUpdateRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type listMPKGOptions struct {
+	Name string `url:"name,omitempty"`
+}
+
+// List lists all the MDM packages.
+func (s *MDMPackagesServiceOp) List(ctx context.Context, opt *ListOptions) ([]MDMPackage, *Response, error) {
+	return s.list(ctx, opt, nil)
+}
+
+// GetByID retrieves a MDM package by id.
+func (s *MDMPackagesServiceOp) GetByID(ctx context.Context, mpID string) (*MDMPackage, *Response, error) {
+	if len(mpID) < 1 {
+		return nil, nil, NewArgError("mpID", "cannot be blank")
+	}
+
+	path := fmt.Sprintf("%s%s/", mpkgBasePath, mpID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mp := new(MDMPackage)
+
+	resp, err := s.client.Do(ctx, req, mp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return mp, resp, err
+}
+
+// GetByName retrieves the MDM packages matching name. Package names are not
+// unique server-side, so this returns a slice.
+func (s *MDMPackagesServiceOp) GetByName(ctx context.Context, name string) ([]MDMPackage, *Response, error) {
+	if len(name) < 1 {
+		return nil, nil, NewArgError("name", "cannot be blank")
+	}
+
+	return s.list(ctx, nil, &listMPKGOptions{Name: name})
+}
+
+// Create a new MDM package.
+func (s *MDMPackagesServiceOp) Create(ctx context.Context, createRequest *MDMPackageCreateRequest) (*MDMPackage, *Response, error) {
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, mpkgBasePath, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mp := new(MDMPackage)
+	resp, err := s.client.Do(ctx, req, mp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return mp, resp, err
+}
+
+// Update a MDM package.
+func (s *MDMPackagesServiceOp) Update(ctx context.Context, mpID string, updateRequest *MDMPackageUpdateRequest) (*MDMPackage, *Response, error) {
+	if len(mpID) < 1 {
+		return nil, nil, NewArgError("mpID", "cannot be blank")
+	}
+
+	if updateRequest == nil {
+		return nil, nil, NewArgError("updateRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf("%s%s/", mpkgBasePath, mpID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPut, path, updateRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mp := new(MDMPackage)
+	resp, err := s.client.Do(ctx, req, mp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return mp, resp, err
+}
+
+// Delete a MDM package.
+func (s *MDMPackagesServiceOp) Delete(ctx context.Context, mpID string) (*Response, error) {
+	if len(mpID) < 1 {
+		return nil, NewArgError("mpID", "cannot be blank")
+	}
+
+	path := fmt.Sprintf("%s%s/", mpkgBasePath, mpID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
+}
+
+// Helper method for listing MDM packages
+func (s *MDMPackagesServiceOp) list(ctx context.Context, opt *ListOptions, mpOpt *listMPKGOptions) ([]MDMPackage, *Response, error) {
+	path := mpkgBasePath
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	path, err = addOptions(path, mpOpt)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resolveAllPages[MDMPackage](ctx, s.client, path)
+}

--- a/mdm_packages_test.go
+++ b/mdm_packages_test.go
@@ -1,0 +1,268 @@
+package goztl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+var mpkgListJSONResponse = `{
+    "count": 1,
+    "results": [
+        {
+            "id": "74d2bc35-7ebe-4d76-8e58-fb9a8b9adc11",
+            "name": "Example",
+            "description": "Example description",
+            "type": "PKG",
+            "source_uri": "https://example.com/example.pkg",
+            "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+            "size": 12345,
+            "filename": "example.pkg",
+            "product_id": "com.example.pkg",
+            "product_version": "1.0",
+            "bundles": [{"id": "com.example.pkg", "version": "1.0"}],
+            "manifest": {"items": []},
+            "created_at": "2022-07-22T01:02:03.444444",
+            "updated_at": "2022-07-22T01:02:03.444444"
+        }
+    ]
+}
+`
+
+var mpkgGetJSONResponse = `
+{
+    "id": "74d2bc35-7ebe-4d76-8e58-fb9a8b9adc11",
+    "name": "Example",
+    "description": "Example description",
+    "type": "PKG",
+    "source_uri": "https://example.com/example.pkg",
+    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "size": 12345,
+    "filename": "example.pkg",
+    "product_id": "com.example.pkg",
+    "product_version": "1.0",
+    "bundles": [{"id": "com.example.pkg", "version": "1.0"}],
+    "manifest": {"items": []},
+    "created_at": "2022-07-22T01:02:03.444444",
+    "updated_at": "2022-07-22T01:02:03.444444"
+}
+`
+
+var mpkgCreateJSONResponse = `
+{
+    "id": "74d2bc35-7ebe-4d76-8e58-fb9a8b9adc11",
+    "name": "Example",
+    "description": "Example description",
+    "type": "PKG",
+    "source_uri": "https://example.com/example.pkg",
+    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "size": 12345,
+    "filename": "example.pkg",
+    "product_id": "com.example.pkg",
+    "product_version": "1.0",
+    "bundles": [{"id": "com.example.pkg", "version": "1.0"}],
+    "manifest": {"items": []},
+    "created_at": "2022-07-22T01:02:03.444444",
+    "updated_at": "2022-07-22T01:02:03.444444"
+}
+`
+
+var mpkgUpdateJSONResponse = `
+{
+    "id": "74d2bc35-7ebe-4d76-8e58-fb9a8b9adc11",
+    "name": "Renamed",
+    "description": "Updated description",
+    "type": "PKG",
+    "source_uri": "https://example.com/example.pkg",
+    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "size": 12345,
+    "filename": "example.pkg",
+    "product_id": "com.example.pkg",
+    "product_version": "1.0",
+    "bundles": [{"id": "com.example.pkg", "version": "1.0"}],
+    "manifest": {"items": []},
+    "created_at": "2022-07-22T01:02:03.444444",
+    "updated_at": "2022-07-22T01:02:03.444444"
+}
+`
+
+func wantMDMPackage(name, description string) MDMPackage {
+	return MDMPackage{
+		ID:             "74d2bc35-7ebe-4d76-8e58-fb9a8b9adc11",
+		Name:           name,
+		Description:    description,
+		Type:           "PKG",
+		SourceURI:      "https://example.com/example.pkg",
+		SHA256:         "0000000000000000000000000000000000000000000000000000000000000000",
+		Size:           12345,
+		Filename:       "example.pkg",
+		ProductID:      "com.example.pkg",
+		ProductVersion: "1.0",
+		Bundles:        []map[string]interface{}{{"id": "com.example.pkg", "version": "1.0"}},
+		Manifest:       map[string]interface{}{"items": []interface{}{}},
+		Created:        Timestamp{referenceTime},
+		Updated:        Timestamp{referenceTime},
+	}
+}
+
+func TestMDMPackagesService_List(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mdm/packages/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", "application/json")
+		fmt.Fprint(w, mpkgListJSONResponse)
+	})
+
+	ctx := context.Background()
+	got, _, err := client.MDMPackages.List(ctx, nil)
+	if err != nil {
+		t.Errorf("MDMPackages.List returned error: %v", err)
+	}
+
+	want := []MDMPackage{wantMDMPackage("Example", "Example description")}
+	if !cmp.Equal(got, want) {
+		t.Errorf("MDMPackages.List returned %+v, want %+v", got, want)
+	}
+}
+
+func TestMDMPackagesService_GetByID(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mdm/packages/74d2bc35-7ebe-4d76-8e58-fb9a8b9adc11/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", "application/json")
+		fmt.Fprint(w, mpkgGetJSONResponse)
+	})
+
+	ctx := context.Background()
+	got, _, err := client.MDMPackages.GetByID(ctx, "74d2bc35-7ebe-4d76-8e58-fb9a8b9adc11")
+	if err != nil {
+		t.Errorf("MDMPackages.GetByID returned error: %v", err)
+	}
+
+	w := wantMDMPackage("Example", "Example description")
+	want := &w
+	if !cmp.Equal(got, want) {
+		t.Errorf("MDMPackages.GetByID returned %+v, want %+v", got, want)
+	}
+}
+
+func TestMDMPackagesService_GetByName(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mdm/packages/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", "application/json")
+		testQueryArg(t, r, "name", "Example")
+		fmt.Fprint(w, mpkgListJSONResponse)
+	})
+
+	ctx := context.Background()
+	got, _, err := client.MDMPackages.GetByName(ctx, "Example")
+	if err != nil {
+		t.Errorf("MDMPackages.GetByName returned error: %v", err)
+	}
+
+	want := []MDMPackage{wantMDMPackage("Example", "Example description")}
+	if !cmp.Equal(got, want) {
+		t.Errorf("MDMPackages.GetByName returned %+v, want %+v", got, want)
+	}
+}
+
+func TestMDMPackagesService_Create(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	createRequest := &MDMPackageCreateRequest{
+		Name:        "Example",
+		Description: "Example description",
+		SourceURI:   "https://example.com/example.pkg",
+		SHA256:      "0000000000000000000000000000000000000000000000000000000000000000",
+	}
+
+	mux.HandleFunc("/mdm/packages/", func(w http.ResponseWriter, r *http.Request) {
+		v := new(MDMPackageCreateRequest)
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", "application/json")
+		testHeader(t, r, "Content-Type", "application/json")
+		assert.Equal(t, createRequest, v)
+
+		fmt.Fprint(w, mpkgCreateJSONResponse)
+	})
+
+	ctx := context.Background()
+	got, _, err := client.MDMPackages.Create(ctx, createRequest)
+	if err != nil {
+		t.Errorf("MDMPackages.Create returned error: %v", err)
+	}
+
+	w := wantMDMPackage("Example", "Example description")
+	want := &w
+	if !cmp.Equal(got, want) {
+		t.Errorf("MDMPackages.Create returned %+v, want %+v", got, want)
+	}
+}
+
+func TestMDMPackagesService_Update(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	updateRequest := &MDMPackageUpdateRequest{
+		Name:        "Renamed",
+		Description: "Updated description",
+	}
+
+	mux.HandleFunc("/mdm/packages/74d2bc35-7ebe-4d76-8e58-fb9a8b9adc11/", func(w http.ResponseWriter, r *http.Request) {
+		v := new(MDMPackageUpdateRequest)
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "Accept", "application/json")
+		testHeader(t, r, "Content-Type", "application/json")
+		assert.Equal(t, updateRequest, v)
+		fmt.Fprint(w, mpkgUpdateJSONResponse)
+	})
+
+	ctx := context.Background()
+	got, _, err := client.MDMPackages.Update(ctx, "74d2bc35-7ebe-4d76-8e58-fb9a8b9adc11", updateRequest)
+	if err != nil {
+		t.Errorf("MDMPackages.Update returned error: %v", err)
+	}
+
+	w := wantMDMPackage("Renamed", "Updated description")
+	want := &w
+	if !cmp.Equal(got, want) {
+		t.Errorf("MDMPackages.Update returned %+v, want %+v", got, want)
+	}
+}
+
+func TestMDMPackagesService_Delete(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mdm/packages/74d2bc35-7ebe-4d76-8e58-fb9a8b9adc11/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := context.Background()
+	_, err := client.MDMPackages.Delete(ctx, "74d2bc35-7ebe-4d76-8e58-fb9a8b9adc11")
+	if err != nil {
+		t.Errorf("MDMPackages.Delete returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Wraps the new mdm/packages/ endpoints (Zentral PR #1496). UUID-keyed resource modelled on monolith_catalogs.go, with two departures from that template:

- GetByName returns []MDMPackage because Package.name is not unique server-side.
- MDMPackageRequest is split into MDMPackageCreateRequest (name, description, source_uri, sha256) and MDMPackageUpdateRequest (name, description), reflecting that the underlying file is immutable post-create. Same shape as tags.go / taxonomies.go.